### PR TITLE
payment types now only accepts numbers for account number

### DIFF
--- a/app/controllers/paymentTypeCtrl.js
+++ b/app/controllers/paymentTypeCtrl.js
@@ -23,7 +23,7 @@ module.exports.promptNewPaymentType = () => {
         {
           name: "account_number",
           description: "Enter account number",
-          type: "number",
+          pattern: /^[0-9]*$/,
           required: true,
           message: "Please enter a number for account number"
         }

--- a/test/product.test.js
+++ b/test/product.test.js
@@ -110,7 +110,7 @@ describe("Get sum SQL", () =>{
 
     it ("Should be an integer",()=>{
         getSumOfProdsSQL(11).then(data =>{
-            isNumber(data[0]['sum(product.price* product.quantity)']);
+            isNumber(data[0]['sum(product.price * order_product.order_quantity)']);
         })
         .catch((err)=>{
             console.log(err, "sum test error");


### PR DESCRIPTION
# Description

Payment types now only accepts numbers for account number

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run ```npm start```
- select an active customer
- select option 3 to add payment option for customer
- when prompted with option to add account number, trying entering a non-number. You should be then presented with a message that you must enter a number.
- enter a number for account number, and make sure it is added to the database.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
